### PR TITLE
Fix missing buttons with ST 4

### DIFF
--- a/src/blame.py
+++ b/src/blame.py
@@ -83,7 +83,7 @@ class Blame(sublime_plugin.TextCommand):
                         # Querystrings can contain the same key multiple times. We use that
                         # functionality to accumulate a list of SHAs to skip over when
                         # a [Prev] button has been clicked multiple times.
-                        qs_skip_keyvals="&".join(
+                        qs_skip_keyvals="&amp;".join(
                             [
                                 "skip={}".format(quote_plus(skipee))
                                 for skipee in sha_skip_list

--- a/src/templates.py
+++ b/src/templates.py
@@ -6,7 +6,7 @@ blame_phantom_html_template = """
             <span class="message">
                 <strong>Git Blame</strong> ({user})
                 {date} {time} |
-                <a href="prev?sha={qs_sha_val}&row_num={qs_row_num_val}&{qs_skip_keyvals}">[Prev]</a>
+                <a href="prev?sha={qs_sha_val}&amp;row_num={qs_row_num_val}&amp;{qs_skip_keyvals}">[Prev]</a>
                 {sha}{sha_not_latest_indicator}
                 <a href="copy?sha={qs_sha_val}">[Copy]</a>
                 <a href="show?sha={qs_sha_val}">[Show]</a>


### PR DESCRIPTION
After recent update, the Git Blame line no longer shows the buttons in Sublime Text 4,

![image](https://user-images.githubusercontent.com/705123/90968151-864e1b00-e4e9-11ea-9296-c4187634fed1.png)


and logs the following error in the console:

	Parse Error: _num=24&">[Prev]</a>
	                2addc0883630
	                <a href="copy?sha=2addc0883630">[Copy]</a>
	                <a href="show?sha=2addc0883630">[Show]</a>
	                <a class="close" href="close">×</a>
	            </span>
	        </div>
	    </body>
	 code: Unexpected character

Let's escape the ampersands to prevent this.
