### PR TITLE
Add inline blame (like in VSCode)

### DIFF
--- a/Settings/Git blame.sublime-settings
+++ b/Settings/Git blame.sublime-settings
@@ -7,6 +7,6 @@
     //     ["-C", "-C"]
     //
     "custom_blame_flags": [],
-    "inline_blame_enabled": true,
+    "inline_blame_enabled": false,
     "inline_blame_delay": 300
 }

--- a/Settings/Git blame.sublime-settings
+++ b/Settings/Git blame.sublime-settings
@@ -6,5 +6,7 @@
     //     ["-M"]
     //     ["-C", "-C"]
     //
-    "custom_blame_flags": []
+    "custom_blame_flags": [],
+    "inline_blame_enabled": true,
+    "inline_blame_delay": 300
 }

--- a/boot.py
+++ b/boot.py
@@ -2,7 +2,7 @@
 # Make Sublime aware of our *{Command,Listener,Handler} classes by importing them:
 from .src.blame import *  # noqa: F401,F403
 from .src.blame_all import *  # noqa: F401,F403
-
+from .src.blame_inline import *  # noqa: F401,F403
 
 def plugin_loaded():
     pass

--- a/src/blame.py
+++ b/src/blame.py
@@ -1,5 +1,3 @@
-from urllib.parse import parse_qs, quote_plus, urlparse
-
 import sublime
 import sublime_plugin
 
@@ -127,48 +125,6 @@ class Blame(BaseBlame, sublime_plugin.TextCommand):
 
     def phantom_exists_for_region(self, region):
         return any(p.region == region for p in self.phantom_set.phantoms)
-
-    def handle_phantom_button(self, href):
-        url = urlparse(href)
-        querystring = parse_qs(url.query)
-        # print(url)
-        # print(querystring)
-
-        if url.path == "copy":
-            sublime.set_clipboard(querystring["sha"][0])
-            sublime.status_message("Git SHA copied to clipboard")
-        elif url.path == "show":
-            sha = querystring["sha"][0]
-            try:
-                desc = self.get_commit_text(sha, self.view.file_name())
-            except Exception as e:
-                self.communicate_error(e)
-                return
-
-            buf = self.view.window().new_file()
-            buf.run_command(
-                "blame_insert_commit_description",
-                {"desc": desc, "scratch_view_name": "commit " + sha},
-            )
-        elif url.path == "prev":
-            sha = querystring["sha"][0]
-            row_num = querystring["row_num"][0]
-            sha_skip_list = querystring.get("skip", [])
-            if sha not in sha_skip_list:
-                sha_skip_list.append(sha)
-            self.run(
-                None,
-                prevving=True,
-                fixed_row_num=int(row_num),
-                sha_skip_list=sha_skip_list,
-            )
-        elif url.path == "close":
-            # Erase all phantoms
-            self.phantom_set.update([])
-        else:
-            self.communicate_error(
-                "No handler for URL path '{0}' in phantom".format(url.path)
-            )
 
 
 class BlameInsertCommitDescription(sublime_plugin.TextCommand):

--- a/src/blame_inline.py
+++ b/src/blame_inline.py
@@ -4,20 +4,27 @@ import sublime_plugin
 
 from .base import BaseBlame
 from .templates import blame_inline_phantom_css, blame_inline_phantom_html_template
-from .settings import pkg_settings, PKG_SETTINGS_KEY_INLINE_BLAME_ENABLED, PKG_SETTINGS_KEY_INLINE_BLAME_DELAY
+from .settings import (
+    pkg_settings,
+    PKG_SETTINGS_KEY_INLINE_BLAME_ENABLED,
+    PKG_SETTINGS_KEY_INLINE_BLAME_DELAY,
+)
+
+INLINE_BLAME_PHANTOM_SET_KEY = "git-blame-inline"
 
 
 class BlameInlineListener(BaseBlame, sublime_plugin.ViewEventListener):
-
     @classmethod
     def is_applicable(cls, settings):
         return pkg_settings().get(PKG_SETTINGS_KEY_INLINE_BLAME_ENABLED)
 
     def __init__(self, view):
         super().__init__(view)
-        self.phantom_set = sublime.PhantomSet(view, 'git-blame')
+        self.phantom_set = sublime.PhantomSet(view, INLINE_BLAME_PHANTOM_SET_KEY)
         self.timer = None
-        self.delay_seconds = pkg_settings().get(PKG_SETTINGS_KEY_INLINE_BLAME_DELAY) / 1000
+        self.delay_seconds = (
+            pkg_settings().get(PKG_SETTINGS_KEY_INLINE_BLAME_DELAY) / 1000
+        )
 
     def extra_cli_args(self, line_num):
         args = ["-L", "{0},{0}".format(line_num)]
@@ -25,6 +32,18 @@ class BlameInlineListener(BaseBlame, sublime_plugin.ViewEventListener):
 
     def _view(self):
         return self.view
+
+    def get_inline_blame_color(self):
+        """
+        This method inverts the current background color and adds alpha, basically doing:
+        #ffffff -> rgba(0, 0, 0, 0.3)
+        The color is than used inside the style template. That is how we make
+        sure inline blame is visible in both dark and light color schemes.
+        """
+        bg = self.view.style().get("background")[1:]
+        colors = [int(bg[i : i + 2], 16) for i in range(0, len(bg), 2)]
+        colors_inverted = [str(255 - i) for i in colors]
+        return "rgba({}, {}, {}, 0.3)".format(*colors_inverted)
 
     def show_inline_blame(self):
         phantoms = []
@@ -41,15 +60,17 @@ class BlameInlineListener(BaseBlame, sublime_plugin.ViewEventListener):
             blame_output = self.get_blame_text(self.view.file_name(), line_num=row + 1)
         except Exception as e:
             return
-        blame = next((self.parse_line(line) for line in blame_output.splitlines()), None)
+        blame = next(
+            (self.parse_line(line) for line in blame_output.splitlines()), None
+        )
         if not blame:
             return
         body = blame_inline_phantom_html_template.format(
-            css=blame_inline_phantom_css,
-            author=blame['author'],
+            css=blame_inline_phantom_css.format(color=self.get_inline_blame_color()),
+            author=blame["author"],
             # TODO: add pretty format of the date, like "3 days ago"
-            date=blame['date'],
-            time=blame['time'] + blame['timezone'],
+            date=blame["date"],
+            time=blame["time"] + blame["timezone"],
             # TODO: add first line of the commit here, but
             #       it requires porcelain format of git blame
             #       and further refactoring of BaseBlame
@@ -59,7 +80,7 @@ class BlameInlineListener(BaseBlame, sublime_plugin.ViewEventListener):
         self.phantom_set.update(phantoms)
 
     def on_selection_modified_async(self):
-        self.view.erase_phantoms('git-blame')
+        self.view.erase_phantoms(INLINE_BLAME_PHANTOM_SET_KEY)
         if self.timer:
             self.timer.cancel()
         self.timer = threading.Timer(self.delay_seconds, self.show_inline_blame)

--- a/src/blame_inline.py
+++ b/src/blame_inline.py
@@ -89,9 +89,17 @@ class BlameInlineListener(BaseBlame, sublime_plugin.ViewEventListener):
         if not self.view.is_dirty():
             self.phantom_set.update(phantoms)
 
-    def on_selection_modified_async(self):
+    def show_inline_blame_handler(self):
         self.view.erase_phantoms(INLINE_BLAME_PHANTOM_SET_KEY)
         if self.timer:
             self.timer.cancel()
         self.timer = threading.Timer(self.delay_seconds, self.show_inline_blame)
         self.timer.start()
+
+    def on_selection_modified_async(self):
+        self.show_inline_blame_handler()
+
+    def on_post_save_async(self):
+        # Redisplay the blame after the file is saved, because there will be
+        # no call to on_selection_modified_async after save.
+        self.show_inline_blame_handler()

--- a/src/blame_inline.py
+++ b/src/blame_inline.py
@@ -33,18 +33,6 @@ class BlameInlineListener(BaseBlame, sublime_plugin.ViewEventListener):
     def _view(self):
         return self.view
 
-    def get_inline_blame_color(self):
-        """
-        This method inverts the current background color and adds alpha, basically doing:
-        #ffffff -> rgba(0, 0, 0, 0.3)
-        The color is than used inside the style template. That is how we make
-        sure inline blame is visible in both dark and light color schemes.
-        """
-        bg = self.view.style().get("background")[1:]
-        colors = [int(bg[i : i + 2], 16) for i in range(0, len(bg), 2)]
-        colors_inverted = [str(255 - i) for i in colors]
-        return "rgba({}, {}, {}, 0.3)".format(*colors_inverted)
-
     def show_inline_blame(self):
         if self.view.is_dirty():
             # If there have already been unsaved edits, stop the git child process from being ran at all.
@@ -70,7 +58,7 @@ class BlameInlineListener(BaseBlame, sublime_plugin.ViewEventListener):
         if not blame:
             return
         body = blame_inline_phantom_html_template.format(
-            css=blame_inline_phantom_css.format(color=self.get_inline_blame_color()),
+            css=blame_inline_phantom_css,
             author=blame["author"],
             # TODO: add pretty format of the date, like "3 days ago"
             date=blame["date"],

--- a/src/blame_inline.py
+++ b/src/blame_inline.py
@@ -1,0 +1,64 @@
+import threading
+import sublime
+import sublime_plugin
+
+from .base import BaseBlame
+from .templates import blame_inline_phantom_css, blame_inline_phantom_html_template
+
+
+class BlameInlineListener(BaseBlame, sublime_plugin.ViewEventListener):
+    def __init__(self, view):
+        super().__init__(view)
+        self.phantom_set = sublime.PhantomSet(view, 'git-blame')
+        self.timer = None
+
+    def extra_cli_args(self, line_num):
+        args = ["-L", "{0},{0}".format(line_num)]
+        return args
+
+    def _view(self):
+        return self.view
+
+    def show_inline_blame(self):
+        phantoms = []
+        sels = self.view.sel()
+        line = self.view.line(sels[0])
+        if line.size() < 2:
+            # avoid weird behaviour of regions on empty lines
+            # < 2 is to check for newline character (full_line is required)
+            return
+        pos = line.end()
+        row, _ = self.view.rowcol(line.begin())
+        anchor = sublime.Region(pos, pos)
+        try:
+            blame_output = self.get_blame_text(self.view.file_name(), line_num=row + 1)
+        except Exception as e:
+            return
+        blame = next((self.parse_line(line) for line in blame_output.splitlines()), None)
+        if not blame:
+            return
+        body = blame_inline_phantom_html_template.format(
+            css=blame_inline_phantom_css,
+            author=blame['author'],
+            # TODO: add pretty format of the date, like "3 days ago"
+            date=blame['date'],
+            time=blame['time'] + blame['timezone'],
+            # TODO: add first line of the commit here, but
+            #       it requires porcelain format of git blame
+            #       and further refactoring of BaseBlame
+        )
+        phantom = sublime.Phantom(anchor, body, sublime.LAYOUT_INLINE)
+        phantoms.append(phantom)
+        self.phantom_set.update(phantoms)
+
+    def on_selection_modified_async(self):
+        s = self.view.settings()
+        phantom_blame_enabled = s.get('inline_blame_enabled', True)
+        phantom_blame_delay = s.get('inline_blame_delay', 300)
+        if not phantom_blame_enabled:
+            return
+        self.view.erase_phantoms('git-blame')
+        if self.timer:
+            self.timer.cancel()
+        self.timer = threading.Timer(phantom_blame_delay / 1000, self.show_inline_blame)
+        self.timer.start()

--- a/src/settings.py
+++ b/src/settings.py
@@ -9,3 +9,6 @@ def pkg_settings():
 
 
 PKG_SETTINGS_KEY_CUSTOMBLAMEFLAGS = "custom_blame_flags"
+
+PKG_SETTINGS_KEY_INLINE_BLAME_ENABLED = "inline_blame_enabled"
+PKG_SETTINGS_KEY_INLINE_BLAME_DELAY = "inline_blame_delay"

--- a/src/templates.py
+++ b/src/templates.py
@@ -100,9 +100,9 @@ blame_inline_phantom_html_template = """
 
 
 blame_inline_phantom_css = """
-    div.phantom {{
-        color: {color};
+    div.phantom {
+        color: color(var(--bluish) blend(var(--background) 60%));
         padding: 0;
         margin-left: 50px;
-    }}
+    }
 """

--- a/src/templates.py
+++ b/src/templates.py
@@ -92,7 +92,7 @@ blame_inline_phantom_html_template = """
         <style>{css}</style>
         <div class="phantom">
             <span class="message">
-                {author},&nbsp;{date}&nbsp;{time}
+                {author},&nbsp;{date}&nbsp;&#183;&nbsp;{summary}&nbsp;<a href="copy?sha={qs_sha_val}">[Copy]</a>&nbsp;<a href="show?sha={qs_sha_val}">[Show]</a>
             </span>
         </div>
     </body>
@@ -104,5 +104,8 @@ blame_inline_phantom_css = """
         color: color(var(--bluish) blend(var(--background) 60%));
         padding: 0;
         margin-left: 50px;
+    }
+    div.phantom a {
+        text-decoration: inherit;
     }
 """

--- a/src/templates.py
+++ b/src/templates.py
@@ -84,3 +84,25 @@ blame_all_phantom_css = """
         background-color: #ffffff18;
     }
 """
+
+# ------------------------------------------------------------
+
+blame_inline_phantom_html_template = """
+    <body id="inline-git-blame">
+        <style>{css}</style>
+        <div class="phantom">
+            <span class="message">
+                {author},&nbsp;{date}&nbsp;{time}
+            </span>
+        </div>
+    </body>
+"""
+
+
+blame_inline_phantom_css = """
+    div.phantom {
+        color: gray;
+        padding: 0;
+        margin-left: 50px;
+    }
+"""

--- a/src/templates.py
+++ b/src/templates.py
@@ -100,9 +100,9 @@ blame_inline_phantom_html_template = """
 
 
 blame_inline_phantom_css = """
-    div.phantom {
-        color: gray;
+    div.phantom {{
+        color: {color};
         padding: 0;
         margin-left: 50px;
-    }
+    }}
 """


### PR DESCRIPTION
Closes #24.

This is basically a rewrite of #27 with a couple of minor changes:

- I didn't add multiline support as @psykzz did, because this is not how GitLens works (it always shows blame on one line)
- Added threading with a configurable timer delay, which fixes the annoyance of blinking blame while typing
- Added global setting to enable/disable this feature (enabled by default)

There are also several caveats, some of which were discussed in previous issues and PRs:

- Weird behavior of phantoms on an empty line is not fixed, I just skip those
- There is still some cursor jumping when adding text on empty lines
- I was not able to add summary to the output, because I think `get_blame_text`first needs a major rewrite without regex and use [`-P` flag](https://git-scm.com/docs/git-blame#Documentation/git-blame.txt--p) of `git blame` (I am willing to contribute here as well)
- The text color is hard-coded in, so it will work properly only for dark color schemes

Things I want to improve after the general idea is accepted:

- Add pretty date formatting, like in vscode, ex. "3 days ago" instead of "2021-05-01 10:00:12+0300"
- Add buttons to phantoms to show full blame or mimic hover effect like in vscode

I am open to any discussion and willing to change the names of the variables as maintainers feel more comfortable with. I was not sure about the code style, because I didn't find any guides, but I can reformat as you wish.

![inline_blame](https://user-images.githubusercontent.com/3424811/120592365-6b301480-c446-11eb-9133-ec9a7694977b.gif)

PS: because of the file structure of the plugin it was very inconvenient to develop, I had to move code around and restart sublime text. Was this a deliberate decision? Sorry for the rant.