### PR TITLE
Add customizable properties to blame_all command

### DIFF
--- a/Settings/Git blame.sublime-settings
+++ b/Settings/Git blame.sublime-settings
@@ -7,6 +7,10 @@
     //     ["-C", "-C"]
     //
     "custom_blame_flags": [],
+    "blame_all_message_max_len": 40,
+    "blame_all_display_author": true,
+    "blame_all_display_date": true,
+    "blame_all_display_time": true,
     "inline_blame_enabled": false,
     "inline_blame_delay": 300
 }

--- a/src/base.py
+++ b/src/base.py
@@ -42,6 +42,7 @@ class BaseBlame(metaclass=ABCMeta):
         return self.run_git(path, cli_args)
 
     def get_commit_message_subject(self, sha, path):
+        if sha == '00000000': return ''
         cli_args = ["show", "--no-color", sha, "--pretty=format:%s", "--no-patch"]
         return self.run_git(path, cli_args)
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -12,3 +12,8 @@ PKG_SETTINGS_KEY_CUSTOMBLAMEFLAGS = "custom_blame_flags"
 
 PKG_SETTINGS_KEY_INLINE_BLAME_ENABLED = "inline_blame_enabled"
 PKG_SETTINGS_KEY_INLINE_BLAME_DELAY = "inline_blame_delay"
+
+PKG_SETTINGS_BLAME_ALL_MESSAGE_MAX_LEN = "blame_all_message_max_len"
+PKG_SETTINGS_BLAME_ALL_DISPLAY_AUTHOR = "blame_all_display_author"
+PKG_SETTINGS_BLAME_ALL_DISPLAY_DATE = "blame_all_display_date"
+PKG_SETTINGS_BLAME_ALL_DISPLAY_TIME = "blame_all_display_time"

--- a/src/templates.py
+++ b/src/templates.py
@@ -57,7 +57,7 @@ blame_all_phantom_html_template = """
         <style>{css}</style>
         <div class="phantom">
             <span class="message">
-                {sha}&nbsp;&nbsp;{author}&nbsp;&nbsp;{date}&nbsp;&nbsp;{time}
+                {sha}{author}{message}{date}{time}
                 <a class="close" href="close">\u00D7</a>
             </span>
         </div>


### PR DESCRIPTION
Allow to display commit message and to customize which info to display

You can now enable/disable:
* author
* date
* time
* message (by setting blame_all_message_max_len=0)

Commit SHA1 is now clickable to see commit content