### PR TITLE
Use Git Log syntax for full diffs

### DIFF
--- a/src/blame.py
+++ b/src/blame.py
@@ -137,7 +137,7 @@ class BlameInsertCommitDescription(sublime_plugin.TextCommand):
     def run(self, edit, desc, scratch_view_name):
         view = self.view
         view.set_scratch(True)
-        view.assign_syntax("Packages/Diff/Diff.sublime-syntax")
+        view.assign_syntax("Packages/Git Formats/Git Log.sublime-syntax")
         view.insert(edit, 0, desc)
         view.set_name(scratch_view_name)
         view.set_read_only(True)


### PR DESCRIPTION
Git Log is basically designed to display repeated `git show` output.

This is intended to enhance formatting of the commit metadata.